### PR TITLE
update gradle to latest, use Kotlin 1.1-M01 EAP

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,11 @@ group 'org.swarmframework'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.0.3'
+    ext.kotlin_version = '1.1-M01'
 
     repositories {
         mavenCentral()
+        maven { url "https://dl.bintray.com/kotlin/kotlin-eap-1.1" }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -19,6 +20,7 @@ sourceCompatibility = 1.5
 
 repositories {
     mavenCentral()
+    maven { url "https://dl.bintray.com/kotlin/kotlin-eap-1.1" }
 }
 
 dependencies {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.0-all.zip


### PR DESCRIPTION
Updated Gradle and Kotlin version. If you're not already, you'll have to set the update channel of your Kotlin plugin for IntelliJ to `Early Access Preview 1.1`.
